### PR TITLE
Pass the encoding argument to run_cmd().

### DIFF
--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -163,7 +163,7 @@ def test_apple_vm_returns_result(mock_handle_provider, mock_run_cmd, mock_config
 
     assert result is True
     mock_run_cmd.assert_called_once_with(
-        ["podman", "machine", "list", "--format", "json", "--all-providers"], ignore_stderr=True
+        ["podman", "machine", "list", "--format", "json", "--all-providers"], ignore_stderr=True, encoding="utf-8"
     )
     mock_handle_provider.assert_called_once_with({"Name": "myvm"}, mock_config)
 


### PR DESCRIPTION
Commit 14c4aaca added an encoding argument to run_cmd() that is passed through to subprocess.run(). Use it to let subprocess.run() handle decoding.

## Summary by Sourcery

Enhancements:
- Delegate stdout decoding to subprocess by passing encoding="utf-8" to run_cmd and remove manual .decode calls in various functions