### PR TITLE
 Add some convenience for developing with emacs. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ uv.lock
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+*~
+\#*#

--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,17 @@ docs-manpages:
 docsite-docs:
 	$(MAKE) -C docsite convert
 
+ifeq (compile,$(findstring compile,$(INSIDE_EMACS)))
+FLAKE8_ARGS += --format=pylint
+endif
+
 .PHONY: lint
 lint:
 ifneq (,$(wildcard /usr/bin/python3))
 	/usr/bin/python3 -m compileall -q -x '\.venv' .
 endif
 	! grep -ri $(EXCLUDE_OPTS) "#\!/usr/bin/python3" .
-	flake8 $(PROJECT_DIR) $(PYTHON_SCRIPTS)
+	flake8 $(FLAKE8_ARGS) $(PROJECT_DIR) $(PYTHON_SCRIPTS)
 	shellcheck *.sh */*.sh */*/*.sh
 
 .PHONY: check-format


### PR DESCRIPTION
This causes error messages to be formatted such that C-x ` (next-error) will go to the flagged line of code.

## Summary by Sourcery

Configure flake8 to use pylint formatting when run inside an Emacs compile buffer for proper next-error navigation

Enhancements:
- Detect Emacs compile buffer via INSIDE_EMACS and set flake8’s --format=pylint argument
- Pass the new FLAKE8_ARGS variable to the flake8 invocation in the Makefile