### PR TITLE
Skip huggingface-cli fallback for llama-server style huggingface uris.

### DIFF
--- a/ramalama/hf_style_repo_base.py
+++ b/ramalama/hf_style_repo_base.py
@@ -247,6 +247,10 @@ class HFStyleRepoModel(Transport, ABC):
         """Return the logout subcommand arguments. Can be overridden for different CLI structures."""
         return ["logout"]
 
+    def should_use_cli_fallback(self):
+        """Return whether CLI fallback should be used on pull failure. Can be overridden to disallow."""
+        return True
+
     def login(self, args):
         if not available(self.get_cli_command()):
             raise NotImplementedError(self.get_missing_message())
@@ -284,7 +288,7 @@ class HFStyleRepoModel(Transport, ABC):
             # No use pulling again
             raise
         except Exception as e:
-            if not available(self.get_cli_command()):
+            if not self.should_use_cli_fallback() or not available(self.get_cli_command()):
                 perror(f"URL pull failed and {self.get_cli_command()} not available")
                 raise KeyError(f"Failed to pull model: {str(e)}")
 

--- a/ramalama/transports/huggingface.py
+++ b/ramalama/transports/huggingface.py
@@ -151,6 +151,7 @@ class Huggingface(HFStyleRepoModel):
 
         self.type = "huggingface"
         self.hf_cli_available = is_hf_cli_available()
+        self.is_llama_server_style = '/' not in self.model_organization
 
     def get_cli_command(self):
         return "hf"
@@ -186,6 +187,14 @@ class Huggingface(HFStyleRepoModel):
 
     def get_cli_download_args(self, directory_path, model):
         return ["hf", "download", "--local-dir", directory_path, model]
+
+    def should_use_cli_fallback(self):
+        """Return whether CLI fallback should be used on pull failure.
+
+        For llama-server style repos skip the CLI fallback since these
+        can be downloaded directly via HTTP using the manifest endpoint.
+        """
+        return not self.is_llama_server_style
 
     def extract_model_identifiers(self):
         model_name, model_tag, model_organization = super().extract_model_identifiers()


### PR DESCRIPTION
Fixes: #1493

## Summary by Sourcery

Detect llama-server style Hugging Face model URIs and disable CLI fallback for them to allow direct HTTP downloads via the manifest endpoint.

Enhancements:
- Add is_llama_server_style flag to Huggingface transport and set it based on repository format
- Introduce should_use_cli_fallback method to conditionally skip CLI fallback for llama-server style repos
- Update pull logic to respect should_use_cli_fallback and avoid using huggingface-cli when disabled