### PR TITLE
Download safetensors models from huggingface.co.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,8 +96,6 @@ skip_if_gh_actions_darwin = pytest.mark.skipif(
 skip_if_windows = pytest.mark.skipif(platform.system() == "Windows", reason="Windows operating system")
 skip_if_not_windows = pytest.mark.skipif(platform.system() != "Windows", reason="not Windows operating system")
 
-skip_if_no_huggingface_cli = pytest.mark.skipif(shutil.which("hf") is None, reason="hf cli not installed")
-
 skip_if_no_llama_bench = pytest.mark.skipif(shutil.which("llama-bench") is None, reason="llama-bench not installed")
 
 skip_if_no_mlx = pytest.mark.skipif(

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -77,7 +77,6 @@ load setup_suite
     is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally"
     run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
 
-    skip_if_no_hf_cli
     run_ramalama pull hf://HuggingFaceTB/SmolLM-135M
     run_ramalama list
     is "$output" ".*HuggingFaceTB/SmolLM-135M" "image was actually pulled locally"
@@ -94,9 +93,6 @@ load setup_suite
     run_ramalama rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
 
     run_ramalama pull hf://owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
-    for i in $(seq 1 3); do
-        is "$output" ".*Downloading Q4_0/SmolLM2-135M-Instruct-Q4_0-0000${i}-of-00003.gguf" "model part ${i} downloaded"
-    done
     run_ramalama list
     is "$output" ".*owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0" "image was actually pulled locally"
     run_ramalama rm hf://owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
@@ -115,29 +111,6 @@ load setup_suite
     is "$output" ".*Not removing snapshot" "snapshot with remaining reference was not deleted"
     run_ramalama --debug rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
     is "$output" ".*Snapshot removed" "snapshot with no remaining references was deleted"
-}
-
-# bats test_tags=distro-integration
-@test "ramalama pull hf cli cache" {
-    skip_if_no_hf_cli
-    hf download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    run_ramalama pull huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    RAMALAMA_TRANSPORT=huggingface run_ramalama pull Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    rm -rf ~/.cache/huggingface/hub/models--Felladrin--gguf-smollm-360M-instruct-add-basics
 }
 
 # bats test_tags=distro-integration


### PR DESCRIPTION
Refactor the fetch_metadata method to try to fetch GGUF metadata from a manifest, and then to try to fetch safetensors metadata from the repo files.

If GGUF, download the model as before.

if safetensors, download the set of files from the repo with https requests. Add an "other_files" category for safetensors files that are neither JSON config files nor .safetensors model files, such as the tokenizer.model file.

Remove code to download models from huggingface.co with the huggingface cli. It didn't work correctly anyway. Stub out the _collect_cli_files and in_existing_cache methods for the huggingface transport.

## Summary by Sourcery

Add direct HTTP-based support for downloading GGUF or safetensors models from Hugging Face, preferring manifest-based GGUF metadata and falling back to safetensors repo inspection while removing reliance on the Hugging Face CLI.

New Features:
- Support discovering and downloading safetensors models and related files from Hugging Face using the repository Files API.
- Handle sharded safetensors models, associated index files, and other auxiliary files as part of the snapshot file list.
- Determine model file type dynamically (GGUF vs safetensors) based on filename extension when building snapshot metadata.

Enhancements:
- Refactor Hugging Face metadata fetching to first use the GGUF manifest and then fall back to safetensors metadata when no GGUF manifest is available.
- Introduce a per-file checksum lookup hook to allow repositories to fetch checksums for additional files as needed.

Chores:
- Remove non-working Hugging Face CLI download integration, stubbing out CLI-based download, cache reuse, and file collection behavior.