### PR TITLE
Make the checks for expected exceptions strict.

### DIFF
--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -181,14 +181,10 @@ def test_load_env_config_coerces_log_level():
     assert cfg["log_level"] == LogLevel.DEBUG
 
 
-@pytest.mark.xfail(raises=ValueError)
-def test_load_env_config_invalid_log_level_raises():
-    load_env_config({"RAMALAMA_LOG_LEVEL": "notalevel"})
-
-
-@pytest.mark.xfail(raises=ValueError)
-def test_load_env_config_invalid_log_level_case_raises():
-    load_env_config({"RAMALAMA_LOG_LEVEL": "InVaLiD"})
+@pytest.mark.parametrize("invalid_level", ["notalevel", "InVaLiD"])
+def test_load_env_config_invalid_log_level_raises(invalid_level):
+    with pytest.raises(ValueError):
+        load_env_config({"RAMALAMA_LOG_LEVEL": invalid_level})
 
 
 class TestGetDefaultEngine:


### PR DESCRIPTION
The tests checking for expected exceptions on invalid log_level configuration should be strict so that the test fails unless the expected exception is raised. Otherwise, failure to raise the expected exception will be noted in the log but will not fail the test.

## Summary by Sourcery

Tests:
- Tighten xfail markers on invalid log level configuration tests so they strictly require a ValueError to be raised.