### PR TITLE
Add type annotations for BaseEngine and info_cli

### DIFF
--- a/ramalama/arg_types.py
+++ b/ramalama/arg_types.py
@@ -33,6 +33,32 @@ class StoreArgType(Protocol):
 StoreArgs = protocol_to_dataclass(StoreArgType)
 
 
+class BaseEngineArgsType(Protocol):
+    """Arguments required by BaseEngine.__init__"""
+
+    # Required attributes (accessed directly)
+    engine: SUPPORTED_ENGINES
+    dryrun: bool
+    quiet: bool
+    image: str
+    # Optional attributes (accessed via getattr)
+    pull: str | None
+    network: str | None
+    oci_runtime: str | None
+    selinux: bool | None
+    nocapdrop: bool | None
+    device: list[str] | None
+    podman_keep_groups: bool | None
+    # Optional attributes for labels
+    MODEL: str | None
+    runtime: str | None
+    port: str | int | None  # Can be string (e.g., "8080:8080") or int
+    subcommand: str | None
+
+
+BaseEngineArgs = protocol_to_dataclass(BaseEngineArgsType)
+
+
 class DefaultArgsType(Protocol):
     container: bool
     runtime: SUPPORTED_RUNTIMES

--- a/ramalama/cli.py
+++ b/ramalama/cli.py
@@ -23,6 +23,7 @@ except Exception:
 
 import ramalama.chat as chat
 from ramalama import engine
+from ramalama.arg_types import DefaultArgsType
 from ramalama.chat import default_prefix
 from ramalama.cli_arg_normalization import normalize_pull_arg
 from ramalama.command.factory import assemble_command
@@ -603,7 +604,7 @@ def _list_models(args):
     return _list_models_from_store(args)
 
 
-def info_cli(args):
+def info_cli(args: DefaultArgsType) -> None:
     info: dict[str, Any] = {
         "Accelerator": get_accel(),
         "Config": load_file_config(),

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -184,7 +184,7 @@ class Engine(BaseEngine):
         port_str = str(port)
         host = getattr(self.args, "host", "0.0.0.0")
         host = f"{host}:" if host != "0.0.0.0" else ""
-        if port_str.count(":") > 0:
+        if ":" in port_str:
             self.add_args("-p", f"{host}{port_str}")
         else:
             self.add_args("-p", f"{host}{port_str}:{port_str}")

--- a/ramalama/engine.py
+++ b/ramalama/engine.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 # Live reference for checking global vars
 import ramalama.common
+from ramalama.arg_types import BaseEngineArgsType
 from ramalama.common import check_nvidia, exec_cmd, get_accel_env_vars, perror, run_cmd
 from ramalama.compat import NamedTemporaryFile
 from ramalama.logger import logger
@@ -19,7 +20,7 @@ from ramalama.logger import logger
 class BaseEngine(ABC):
     """General-purpose engine for running podman or docker commands"""
 
-    def __init__(self, args):
+    def __init__(self, args: BaseEngineArgsType) -> None:
         base = os.path.basename(args.engine)
         self.use_docker: bool = base == "docker"
         self.use_podman: bool = base == "podman"
@@ -144,7 +145,7 @@ class BaseEngine(ABC):
 class Engine(BaseEngine):
     """Engine for executing 'podman run'"""
 
-    def __init__(self, args):
+    def __init__(self, args: BaseEngineArgsType) -> None:
         super().__init__(args)
         self.add_detach_option()
         self.add_device_options()
@@ -175,15 +176,18 @@ class Engine(BaseEngine):
             self.add_env_option(env)
 
     def add_port_option(self) -> None:
-        if getattr(self.args, "port", "") == "":
+        port = getattr(self.args, "port", "")
+        if not port:
             return
 
+        # Convert port to string for processing
+        port_str = str(port)
         host = getattr(self.args, "host", "0.0.0.0")
         host = f"{host}:" if host != "0.0.0.0" else ""
-        if self.args.port.count(":") > 0:
-            self.add_args("-p", f"{host}{self.args.port}")
+        if port_str.count(":") > 0:
+            self.add_args("-p", f"{host}{port_str}")
         else:
-            self.add_args("-p", f"{host}{self.args.port}:{self.args.port}")
+            self.add_args("-p", f"{host}{port_str}:{port_str}")
 
     def add_privileged_options(self) -> None:
         if getattr(self.args, "privileged", False):


### PR DESCRIPTION
Create BaseEngineArgsType Protocol to properly type engine initialization arguments.

Add DefaultArgsType annotation to info_cli function.

This resolves annotation-unchecked notes from mypy type checking.

Fix port handling in Engine.add_port_option to support both string and int types.


Assisted-by: Claude Code <noreply@anthropic.com>

## Summary by Sourcery

Add type annotations for engine initialization and CLI info handling while improving port option processing for the engine.

New Features:
- Introduce BaseEngineArgsType protocol and corresponding BaseEngineArgs dataclass for typing engine initialization arguments.

Bug Fixes:
- Correct Engine.add_port_option to handle both string and integer port values consistently when constructing port mappings.

Enhancements:
- Annotate BaseEngine and Engine constructors and the info_cli function with precise argument and return types to satisfy static type checking.