### PR TITLE
Download safetensors models from huggingface.co with https.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -96,8 +96,6 @@ skip_if_gh_actions_darwin = pytest.mark.skipif(
 skip_if_windows = pytest.mark.skipif(platform.system() == "Windows", reason="Windows operating system")
 skip_if_not_windows = pytest.mark.skipif(platform.system() != "Windows", reason="not Windows operating system")
 
-skip_if_no_huggingface_cli = pytest.mark.skipif(shutil.which("hf") is None, reason="hf cli not installed")
-
 skip_if_no_llama_bench = pytest.mark.skipif(shutil.which("llama-bench") is None, reason="llama-bench not installed")
 
 skip_if_no_mlx = pytest.mark.skipif(

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -77,7 +77,6 @@ load setup_suite
     is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally"
     run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
 
-    skip_if_no_hf_cli
     run_ramalama pull hf://HuggingFaceTB/SmolLM-135M
     run_ramalama list
     is "$output" ".*HuggingFaceTB/SmolLM-135M" "image was actually pulled locally"
@@ -94,9 +93,6 @@ load setup_suite
     run_ramalama rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
 
     run_ramalama pull hf://owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
-    for i in $(seq 1 3); do
-        is "$output" ".*Downloading Q4_0/SmolLM2-135M-Instruct-Q4_0-0000${i}-of-00003.gguf" "model part ${i} downloaded"
-    done
     run_ramalama list
     is "$output" ".*owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0" "image was actually pulled locally"
     run_ramalama rm hf://owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
@@ -115,29 +111,6 @@ load setup_suite
     is "$output" ".*Not removing snapshot" "snapshot with remaining reference was not deleted"
     run_ramalama --debug rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
     is "$output" ".*Snapshot removed" "snapshot with no remaining references was deleted"
-}
-
-# bats test_tags=distro-integration
-@test "ramalama pull hf cli cache" {
-    skip_if_no_hf_cli
-    hf download Felladrin/gguf-smollm-360M-instruct-add-basics smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    run_ramalama pull hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm hf://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    run_ramalama pull huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    RAMALAMA_TRANSPORT=huggingface run_ramalama pull Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-    run_ramalama list
-    is "$output" ".*Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS" "image was actually pulled locally from hf-cli cache"
-    run_ramalama rm huggingface://Felladrin/gguf-smollm-360M-instruct-add-basics/smollm-360M-instruct-add-basics.IQ2_XXS.gguf
-
-    rm -rf ~/.cache/huggingface/hub/models--Felladrin--gguf-smollm-360M-instruct-add-basics
 }
 
 # bats test_tags=distro-integration


### PR DESCRIPTION
Refactor the fetch_metadata method to attempt to fetch GGUF metadata from a manifest, and then to attempt to fetch safetensors metadata from the repo tree, including potentially paginated lists, although there does not seem to be a huggingface model that is big enough to require pagination yet.

To fetch a safetensors model, download the set of files from the repo with https requests. Add an "other_files" category for safetensors files that are neither JSON config files nor .safetensors model files, such as the tokenizer.model file.

Remove code to download models from huggingface.co with the huggingface cli. It didn't work correctly anyway. Stub out the _collect_cli_files and in_existing_cache methods for the huggingface transport.

Enable bats test of downloading safetensors models from huggingface. Remove bats test and e2e test of downloading models with the huggingface cli. Adjust test expectation for split safetensors model.

Fixes: #1493

## Summary by Sourcery

Switch Hugging Face model downloads to use the HTTPS API directly and extend metadata handling to support safetensors-based models alongside GGUF.

New Features:
- Support discovering and downloading safetensors models and related files from Hugging Face repositories via the HTTPS Files API, including sharded models and index files.

Bug Fixes:
- Avoid failing when a Hugging Face repository lacks GGUF manifest data by falling back to safetensors metadata discovery.

Enhancements:
- Refine Hugging Face metadata fetching to prioritize GGUF manifests and add a secondary safetensors metadata path, with pagination-aware file listing.
- Classify non-config, non-model safetensors artifacts as generic files so they are tracked and downloaded as part of the snapshot.
- Automatically infer snapshot file types from file extensions at download time instead of assuming GGUF.

Tests:
- Enable and adjust system tests for pulling safetensors models from Hugging Face while removing tests that relied on the Hugging Face CLI cache and download behavior.

Chores:
- Remove unused Hugging Face CLI-based download paths and cache reuse logic, stubbing their interfaces to reflect that CLI downloads are no longer supported.